### PR TITLE
fix: run toast listener once

### DIFF
--- a/components/ui/use-toast.ts
+++ b/components/ui/use-toast.ts
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- ensure toast listener effect runs only once by removing `state` from dependency array

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689574fba618832cb24fcc9fc970da75