### PR TITLE
🔒 Harden sidebar state cookie with Secure and SameSite=Strict attributes

### DIFF
--- a/__tests__/components/sidebar_cookie.test.tsx
+++ b/__tests__/components/sidebar_cookie.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar'
+
+// Mock useIsMobile to avoid issues with window.matchMedia
+jest.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => false
+}))
+
+describe('Sidebar Cookie Security', () => {
+  let cookieSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    // Mock document.cookie
+    cookieSpy = jest.spyOn(document, 'cookie', 'set')
+    // Clear cookie mock before each test
+    cookieSpy.mockClear()
+  })
+
+  afterEach(() => {
+    cookieSpy.mockRestore()
+  })
+
+  it('sets sidebar cookie with Secure and SameSite=Strict attributes when toggled', () => {
+    render(
+      <SidebarProvider defaultOpen={true}>
+        <SidebarTrigger />
+      </SidebarProvider>
+    )
+
+    const trigger = screen.getByRole('button', { name: /toggle sidebar/i })
+
+    act(() => {
+      fireEvent.click(trigger)
+    })
+
+    // The cookie should be set when the sidebar is toggled
+    expect(cookieSpy).toHaveBeenCalled()
+
+    const cookieValue = cookieSpy.mock.calls[0][0]
+    expect(cookieValue).toContain('sidebar:state=false')
+    expect(cookieValue).toContain('Secure')
+    expect(cookieValue).toContain('SameSite=Strict')
+    expect(cookieValue).toContain('path=/')
+    expect(cookieValue).toContain('max-age=')
+  })
+})

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -84,7 +84,7 @@ const SidebarProvider = React.forwardRef<
         }
 
         // This sets the cookie to keep the sidebar state.
-        document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`
+        document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}; Secure; SameSite=Strict`
       },
       [setOpenProp, open]
     )


### PR DESCRIPTION
🎯 **What:** Insecure Cookie Settings for `sidebar:state`.
⚠️ **Risk:** The `sidebar:state` cookie was missing `Secure` and `SameSite` attributes. Without `Secure`, the cookie could be sent over unencrypted connections (HTTP). Without `SameSite`, it could be vulnerable to CSRF-like scenarios where the state might be manipulated by cross-site requests.
🛡️ **Solution:** Appended `; Secure; SameSite=Strict` to the `document.cookie` string in `components/ui/sidebar.tsx`. I also added a unit test to ensure these attributes are correctly set.

---
*PR created automatically by Jules for task [13549533368755005025](https://jules.google.com/task/13549533368755005025) started by @adityafakhrii*